### PR TITLE
Exempt message-mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,24 @@
 language: emacs-lisp
+arch:
+  - amd64
+  - ppc64le
+jobs:
+  exclude:
+   - arch: ppc64le   
+     env: EMACS=emacs-snapshot
 before_install:
   - git submodule update --init
+  - if [ "$TRAVIS_CPU_ARCH" = 'ppc64le' ]; then
+      sudo apt-get update && 
+      sudo apt-get install -y emacs;
+    fi
   - if [ "$EMACS" = 'emacs-snapshot' ]; then
       sudo add-apt-repository -y ppa:cassou/emacs &&
       sudo apt-get update --allow-unauthenticated -qq &&
       sudo apt-get install -qq
           emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot;
     fi
+ 
 env:
   - EMACS=emacs
   - EMACS=emacs-snapshot

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/lewang/ws-butler.png)](http://travis-ci.org/lewang/ws-butler)
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/ws-butler.svg)](https://elpa.nongnu.org/nongnu/ws-butler.html)
 
 ## ws-butler -- an unobtrusive way to trim spaces from end of line
 

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -96,6 +96,7 @@ changed in this specific way."
     comint-mode
     term-mode
     eshell-mode
+    diff-mode
     markdown-mode)
   "Don't enable ws-butler in modes that inherit from these.
 

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -10,7 +10,7 @@
 ;; Maintainer: Le Wang
 
 ;; Created: Sat Jan  5 16:49:23 2013 (+0800)
-;; Version: 0.6
+;; Version: 0.7
 ;; Last-Updated:
 ;;           By:
 ;; URL: https://github.com/lewang/ws-butler

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -80,7 +80,7 @@ i.e. only the \"virtual\" space is preserved in the buffer."
 
 (defcustom ws-butler-convert-leading-tabs-or-spaces
   nil
-  "Make leading whitespace be tabs or spaces
+  "Make leading whitespace be tabs or spaces.
 
 If `indent-tabs-mode' is non-nil, call `tabify', else call
 `untabify'. Do neither if `smart-tabs-mode' is enabled for this
@@ -149,7 +149,7 @@ Also see `require-final-newline'."
      (replace-match ""))))
 
 (defun ws-butler-maybe-trim-eob-lines (last-modified-pos)
-  "Delete extra newlines at end of buffer if LAST-MODIFIED-POS is in the patch of excess newlines."
+  "Trim newlines at EOB if LAST-MODIFIED-POS is inside the excess newlines."
   (interactive (list nil))
   (unless buffer-read-only
     (unless last-modified-pos
@@ -183,7 +183,7 @@ replaced by spaces, and vice versa if t."
      (when (and ws-butler-convert-leading-tabs-or-spaces
                 (not (bound-and-true-p smart-tabs-mode)))
        ;; convert leading tabs to spaces or v.v.
-       (let ((eol (point-at-eol)))
+       (let ((eol (line-end-position)))
          (if indent-tabs-mode
              (progn
                (skip-chars-forward "\t" eol)
@@ -242,11 +242,11 @@ ensure point doesn't jump due to white space trimming."
      (lambda (_prop beg end)
        (save-excursion
          (setq beg (progn (goto-char beg)
-                          (point-at-bol))
+                          (line-end-position))
                ;; Subtract one from end to overcome Emacs bug #17784, since we
                ;; always expand to end of line anyway, this should be OK.
                end (progn (goto-char (1- end))
-                          (point-at-eol))))
+                          (line-end-position))))
        (when (funcall ws-butler-trim-predicate beg end)
          (ws-butler-clean-region beg end))
        (setq last-end end)))
@@ -259,6 +259,8 @@ ensure point doesn't jump due to white space trimming."
                              (remove-list-of-text-properties start end '(ws-butler-chg))))))
 
 (defun ws-butler-after-change (beg end length-before)
+  "Update ws-butler text properties.
+See `after-change-functions' for explanation of BEG, END & LENGTH-BEFORE."
   (let ((type (if (and (= beg end) (> length-before 0))
                   'delete
                 'chg)))
@@ -319,6 +321,7 @@ for lines modified by you."
 ;;;###autoload
 (define-globalized-minor-mode ws-butler-global-mode ws-butler-mode
   (lambda ()
+    "Enable `ws-butler-mode' unless current major mode is exempt."
     (unless (apply #'derived-mode-p ws-butler-global-exempt-modes)
       (ws-butler-mode))))
 

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -54,7 +54,7 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (eval-and-compile
   (unless (fboundp 'setq-local)

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -140,7 +140,7 @@ Also see `require-final-newline'."
      ;;
      ;; We refuse to remove final-newline regardless of the value of
      ;; `require-final-newline'
-     (when (looking-at "\n\\(\n\\|\\'\\)")
+     (when (looking-at-p "\n\\(?:\n\\|\\'\\)")
        (forward-char 1)))
    (when require-final-newline
      (unless (bolp)

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -93,6 +93,7 @@ changed in this specific way."
 
 (defcustom ws-butler-global-exempt-modes
   '(special-mode
+    minibuffer-mode
     comint-mode
     term-mode
     eshell-mode

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -279,15 +279,15 @@ ensure point doesn't jump due to white space trimming."
   (ws-butler-clear-properties)
   ;; go to saved line+col
   (when ws-butler-presave-coord
-    (with-silent-modifications
-      (let (remaining-lines)
-        (ws-butler-with-save
-         (widen)
-         (goto-char (point-min))
-         (setq remaining-lines (forward-line (1- (car ws-butler-presave-coord)))))
-        (unless (eq remaining-lines 0)
-          (insert (make-string remaining-lines ?\n))))
-      (move-to-column (cadr ws-butler-presave-coord) t))))
+    (let (remaining-lines)
+      (ws-butler-with-save
+       (widen)
+       (goto-char (point-min))
+       (setq remaining-lines (forward-line (1- (car ws-butler-presave-coord)))))
+      (unless (eq remaining-lines 0)
+        (insert (make-string remaining-lines ?\n))))
+    (move-to-column (cadr ws-butler-presave-coord) t)
+    (set-buffer-modified-p nil)))
 
 (defun ws-butler-before-revert ()
   "Clear `ws-butler-presave-coord'."

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -92,7 +92,11 @@ changed in this specific way."
   :group 'ws-butler)
 
 (defcustom ws-butler-global-exempt-modes
-  '(markdown-mode)
+  '(special-mode
+    comint-mode
+    term-mode
+    eshell-mode
+    markdown-mode)
   "Don't enable ws-butler in modes that inherit from these.
 
 This should be a list of trailing whitespace significant major-modes."

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -98,6 +98,7 @@ changed in this specific way."
     term-mode
     eshell-mode
     diff-mode
+    message-mode
     markdown-mode)
   "Don't enable ws-butler in modes that inherit from these.
 


### PR DESCRIPTION
Emails can contain whitespace-sensitive patches. The standard signature
separator and format=flowed also use trailing whitespace.